### PR TITLE
feat: Shell completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +166,7 @@ version = "2.0.1"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "colored",
  "home",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ home = "^0.5.5"
 clap = {version = "^4.3.21", features = [ "derive" ]}
 anyhow = "^1.0.72"
 colored = "^2.0.4"
+clap_complete = "4.5.1"
 
 [[bin]]
 name = "sk"

--- a/README.md
+++ b/README.md
@@ -19,16 +19,24 @@ Skely uses the `SK_PLACEHOLDER` enviroment variable to determine a placeholder s
 
 ## Usage
 
-### Add
-Skely can add new skeletons by passing Skely a directory or file to copy. `sk add foo/` will add `foo/` as a skeleton, found at `~/.config/sk/skeletons/foo/`.
-
 ### New
 To create a new project using skeleton do `sk new <PROJECT NAME>`. `sk new foo` will create project at `/foo`. Additional options can be found using `sk new --help`.
+
+### Add
+Skely can add new skeletons by passing Skely a directory or file to copy. `sk add foo/` will add `foo/` as a skeleton, found at `~/.config/sk/skeletons/foo/`.
 
 ### Remove
 To remove a skeleton do `sk remove <PROJECT NAME>`.
 
 ### List
 To list all configured skeletons do `sk list`.
+
+### Completion
+To generate shell completion for Skelly do `sk completion <SHELL>`. To see supported shells do `sk completion --help`. Installing completion scripts is dependent on your shell. With zsh and [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh) it would look something like this:
+```zsh
+mkdir ~/.oh-my-zsh/completions
+sk completion zsh > ~/.oh-my-zsh/completions/_sk
+omz reload
+```
 
 If you've read this far, thank you for taking interest in my software, it is much appreciated :).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use clap_complete::{Generator, Shell};
 
 #[derive(Parser, Debug, PartialEq)]
 #[command(name = "sk")]
@@ -44,5 +45,10 @@ pub enum Commands {
         /// Removes without confirming
         #[arg(short, long)]
         no_confirm: bool,
+    },
+    /// Generates shell completion for provided shell
+    Completion {
+        #[arg(value_enum)]
+        shell: Shell,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,8 @@
 use anyhow::{anyhow, Context, Result};
+use clap::Command;
+use clap::CommandFactory;
+use clap_complete::generate;
+use clap_complete::Generator;
 use cli::{Cli, Commands};
 use colored::{ColoredString, Colorize};
 use std::env;
@@ -15,6 +19,10 @@ mod util;
 
 static PLACEHOLDER_ENV_VAR: &str = "SK_PLACEHOLDER";
 
+fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
+    generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
+}
+
 fn main() -> Result<()> {
     let args = Cli::parse();
     match args.command {
@@ -22,6 +30,11 @@ fn main() -> Result<()> {
         Commands::New { id, path, name } => new(id, path, name)?,
         Commands::List => list()?,
         Commands::Remove { id, no_confirm } => remove(id, no_confirm)?,
+        Commands::Completion { shell } => {
+            let mut cmd = Cli::command();
+            eprintln!("Generating completion file for {shell:?}...");
+            print_completions(shell, &mut cmd);
+        },
     }
 
     Ok(())


### PR DESCRIPTION
Implements some shell completion support using [clap_complete](https://docs.rs/clap_complete/latest/clap_complete/).

Not completely finished feature. Still need to add some completion for selecting skeletons, i.e. `sk remove <tab>` lists configured skeletons. Will have to wrangle with clap_complete's capabilities.